### PR TITLE
added transparency support

### DIFF
--- a/dist/aframe-sprite-component.js
+++ b/dist/aframe-sprite-component.js
@@ -52,7 +52,10 @@
 	        },
 	        resize:{
 	            default: '1 1 1'
-	        }
+	        },
+			alpha : {
+				default : 0.4
+			},
 	    },
 
 
@@ -69,7 +72,9 @@
 	        this.map = this.textureLoader.load(this.data.src);
 
 	        this.material = new THREE.SpriteMaterial({
-	            map: this.map
+	            map: this.map,
+				transparent  : true, 
+				alphaTest : this.data.alpha
 	        });
 
 	        this.sprite = new THREE.Sprite(this.material);


### PR DESCRIPTION
Adds a transparency support for png texture with transparency, 
alphaTest is a parameter you can adjust.

Example of multiple sprite with transparency
![image](https://user-images.githubusercontent.com/32254285/117437437-69b02100-af5a-11eb-93cc-ff8613e207a5.png)
